### PR TITLE
feat: update video API integration with new fields and formats

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -61,6 +61,7 @@
         "@testing-library/jest-dom": "^6.5.0",
         "@testing-library/react": "^16.1.0",
         "@testing-library/user-event": "^14.5.2",
+        "@types/date-fns": "^2.6.3",
         "@types/jest": "^29.5.13",
         "@types/node": "^20",
         "@types/react": "^19",
@@ -667,6 +668,8 @@
     "@types/d3-time": ["@types/d3-time@3.0.4", "", {}, "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g=="],
 
     "@types/d3-timer": ["@types/d3-timer@3.0.2", "", {}, "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw=="],
+
+    "@types/date-fns": ["@types/date-fns@2.6.3", "", { "dependencies": { "date-fns": "*" } }, "sha512-Ke1lw2Ni1t/wMUoLtKFmSNCLozcTBd6vmMqFP4hRzXn6qzkNt97bPAX0x5Y/c15DP43kKvwW1ycStD5+43jVQA=="],
 
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
 

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "@testing-library/jest-dom": "^6.5.0",
     "@testing-library/react": "^16.1.0",
     "@testing-library/user-event": "^14.5.2",
+    "@types/date-fns": "^2.6.3",
     "@types/jest": "^29.5.13",
     "@types/node": "^20",
     "@types/react": "^19",

--- a/src/__tests__/api-client.test.ts
+++ b/src/__tests__/api-client.test.ts
@@ -83,15 +83,20 @@ describe('ApiClient', () => {
       const mockVideos: Video[] = [
         {
           id: 1,
-          title: 'Test Video',
-          description: 'Test Description',
+          // Используем новые поля API
+          video_title: 'Test Video',
+          video_description: 'Test Description',
+          video_views: 100,
+          channel_name: 'Test Channel',
+          profile_image: 'test-avatar.jpg',
+          file_path: 'videos/test.mp4',
+          thumbnail_path: 'thumbnails/test.jpg',
           category: 'Texnologiya',
-          channel_id: 1,
-          video_url: 'https://example.com/video.mp4',
-          views_count: 100,
-          likes_count: 10,
-          dislikes_count: 2,
-          created_at: '2023-01-01T00:00:00Z'
+          like_amount: 10,
+          dislike_amount: 2,
+          created_at: '2025-07-03T15:30:00',
+          duration: 120,
+          duration_video: '02:00'
         }
       ]
 

--- a/src/__tests__/utils/format.test.ts
+++ b/src/__tests__/utils/format.test.ts
@@ -4,7 +4,8 @@ import {
   formatFileSize,
   formatRelativeTime,
   truncateText,
-  formatSubscriberCount,
+  formatApiDate,
+  formatVideoDuration,
 } from '@/lib/utils/format'
 
 describe('Format Utils', () => {
@@ -130,15 +131,32 @@ describe('Format Utils', () => {
     })
   })
 
-  describe('formatSubscriberCount', () => {
-    test('formats singular subscriber', () => {
-      expect(formatSubscriberCount(1)).toBe('1 subscriber')
+  describe('formatApiDate', () => {
+    test('formats ISO date to DD.MM.YYYY HH:mm format', () => {
+      expect(formatApiDate('2025-07-03T15:30:00')).toBe('03.07.2025 15:30')
+      expect(formatApiDate('2025-12-25T09:15:30')).toBe('25.12.2025 09:15')
     })
 
-    test('formats plural subscribers', () => {
-      expect(formatSubscriberCount(2)).toBe('2 subscribers')
-      expect(formatSubscriberCount(1000)).toBe('1.0K subscribers')
-      expect(formatSubscriberCount(1500000)).toBe('1.5M subscribers')
+    test('handles invalid date gracefully', () => {
+      expect(formatApiDate('invalid-date')).toBe('invalid-date')
+      expect(formatApiDate('')).toBe('')
+    })
+  })
+
+  describe('formatVideoDuration', () => {
+    test('formats duration string', () => {
+      expect(formatVideoDuration('02:30')).toBe('02:30')
+      expect(formatVideoDuration('1:45:20')).toBe('1:45:20')
+    })
+
+    test('formats duration from seconds', () => {
+      expect(formatVideoDuration(150)).toBe('2:30')
+      expect(formatVideoDuration(3661)).toBe('1:01:01')
+    })
+
+    test('handles undefined and invalid input', () => {
+      expect(formatVideoDuration(undefined)).toBe('0:00')
+      expect(formatVideoDuration('invalid')).toBe('0:00')
     })
   })
 })

--- a/src/components/video/video-grid.tsx
+++ b/src/components/video/video-grid.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link'
 import { Card, CardContent } from '@/components/ui/card'
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar'
 import { buildImageUrl } from '@/lib/api-config'
+import { formatApiDate } from '@/lib/utils/format'
 import type { Video } from '@/types/api'
 import Image from 'next/image'
 
@@ -35,8 +36,12 @@ interface VideoCardProps {
 }
 
 function VideoCard({ video }: VideoCardProps) {
-  const channelName = video.name // Используем поле name для имени канала
+  // Используем новые поля API с fallback на старые
+  const channelName = video.channel_name || video.name || 'Unknown Channel'
   const profileImage = video.profile_image
+  const videoTitle = video.video_title || video.title || 'Untitled'
+  const videoViews = video.video_views || video.views || 0
+  const videoDuration = video.duration_video || video.duration
 
   return (
     <Card className="overflow-hidden hover:shadow-md transition-shadow">
@@ -47,7 +52,7 @@ function VideoCard({ video }: VideoCardProps) {
             {video.thumbnail_path ? (
               <Image
                 src={buildImageUrl(video.thumbnail_path)}
-                alt={video.title}
+                alt={videoTitle}
                 className="w-full h-full object-cover"
                 fill
                 sizes="(max-width: 768px) 100vw, 33vw"
@@ -60,9 +65,9 @@ function VideoCard({ video }: VideoCardProps) {
             )}
             
             {/* Продолжительность видео */}
-            {video.duration && (
+            {videoDuration && (
               <div className="absolute bottom-2 right-2 bg-black/70 text-white text-xs px-1.5 py-0.5 rounded">
-                {formatDuration(video.duration)}
+                {typeof videoDuration === 'string' ? videoDuration : formatDuration(videoDuration)}
               </div>
             )}
           </div>
@@ -86,7 +91,7 @@ function VideoCard({ video }: VideoCardProps) {
               {/* Детали видео */}
               <div className="flex-1 min-w-0">
                 <h3 className="font-medium line-clamp-2 text-sm leading-5 mb-1">
-                  {video.title}
+                  {videoTitle}
                 </h3>
                 <p className="text-sm text-muted-foreground mb-1">
                   <Link href={`/channel?name=${encodeURIComponent(channelName)}`} className="hover:underline focus:underline">
@@ -94,10 +99,10 @@ function VideoCard({ video }: VideoCardProps) {
                   </Link>
                 </p>
                 <div className="flex items-center gap-1 text-xs text-muted-foreground">
-                  <span>{video.views || 0} просмотров</span>
+                  <span>{videoViews} просмотров</span>
                   <span>•</span>
                   <span>
-                    {video.created_at}
+                    {formatApiDate(video.created_at)}
                   </span>
                 </div>
               </div>

--- a/src/hooks/use-video-stats.ts
+++ b/src/hooks/use-video-stats.ts
@@ -82,12 +82,12 @@ export function useVideoStats(options: UseVideoStatsOptions) {
       const apiVideo = videos.find(v => v.id.toString() === videoId)
       
       if (apiVideo) {
-        // Используем данные из API напрямую
+        // Используем данные из API с новыми полями
         setState(prev => ({
           ...prev,
-          views: apiVideo.views || 0,
-          likesCount: apiVideo.like_amount || 0, // Используем like_amount из API!
-          dislikesCount: 0, // Нет в API
+          views: apiVideo.video_views || apiVideo.views || 0,
+          likesCount: apiVideo.like_amount || 0,
+          dislikesCount: apiVideo.dislike_amount || 0, // Теперь есть в API
           isLoading: false,
         }))
       } else {

--- a/src/lib/utils/format.ts
+++ b/src/lib/utils/format.ts
@@ -1,5 +1,8 @@
 // src/lib/utils/format.ts
 
+import { format, parseISO } from 'date-fns'
+import { ru } from 'date-fns/locale'
+
 /**
  * Format number of views in YouTube style
  * @param views - Number of views
@@ -111,4 +114,50 @@ export const formatShortNumber = (count: number): string => {
     return `${(count / 1000).toFixed(1)}K`
   }
   return count.toString()
+}
+
+/**
+ * Format API date from "2025-07-03T15:30:00" to "03.07.2025 15:30"
+ * @param dateString - Date string from API
+ * @returns Formatted date string
+ */
+export const formatApiDate = (dateString: string): string => {
+  try {
+    // Парсим ISO строку даты
+    const date = parseISO(dateString)
+    
+    // Форматируем в нужный формат
+    return format(date, 'dd.MM.yyyy HH:mm', { locale: ru })
+  } catch (error) {
+    // Если не удалось распарсить, возвращаем исходную строку
+    console.warn('Failed to parse date:', dateString, error)
+    return dateString
+  }
+}
+
+/**
+ * Format duration from video API (seconds or duration_video field)
+ * @param duration - Duration in seconds or string format like "02:00"
+ * @returns Formatted duration string
+ */
+export const formatVideoDuration = (duration: number | string | undefined): string => {
+  if (!duration) return '0:00'
+  
+  // Если уже строка в правильном формате, возвращаем как есть
+  if (typeof duration === 'string' && duration.includes(':')) {
+    return duration
+  }
+  
+  // Если число, форматируем из секунд
+  if (typeof duration === 'number') {
+    return formatDuration(duration)
+  }
+  
+  // Пытаемся преобразовать строку в число
+  const seconds = parseInt(duration.toString(), 10)
+  if (!isNaN(seconds)) {
+    return formatDuration(seconds)
+  }
+  
+  return '0:00'
 }

--- a/src/lib/utils/video-mapper.ts
+++ b/src/lib/utils/video-mapper.ts
@@ -2,7 +2,7 @@
 
 import type { Video as ApiVideo } from '@/types/api'
 import type { Video } from '@/types/video'
-import { formatDuration, formatRelativeTime } from '@/lib/utils/format'
+import { formatApiDate, formatVideoDuration } from '@/lib/utils/format'
 
 /**
  * Преобразует видео из API формата в формат компонентов
@@ -13,15 +13,16 @@ export function mapApiVideoToVideo(apiVideo: ApiVideo): Video {
   
   return {
     id: apiVideo.id.toString(),
-    title: apiVideo.title,
-    description: apiVideo.description,
-    views: apiVideo.views || 0,
+    // Используем новые поля API с fallback на старые для совместимости
+    title: apiVideo.video_title || apiVideo.title || 'Untitled',
+    description: apiVideo.video_description || apiVideo.description || '',
+    views: apiVideo.video_views || apiVideo.views || 0,
     likes: apiVideo.like_amount || 0,
-    dislikes: 0, // Нет в API
+    dislikes: apiVideo.dislike_amount || 0,
     commentsCount: 0, // Нет в API, пока устанавливаем 0
     channel: {
       id: `channel-${apiVideo.id}`, // Используем уникальный ID для каждого видео
-      name: apiVideo.name || 'Unknown Channel',
+      name: apiVideo.channel_name || apiVideo.name || 'Unknown Channel',
       avatarUrl: apiVideo.profile_image 
         ? `${baseUrl}/images/${apiVideo.profile_image}`
         : '/avatars/g53bfu5y.png',
@@ -37,8 +38,8 @@ export function mapApiVideoToVideo(apiVideo: ApiVideo): Video {
     videoUrl: apiVideo.file_path 
       ? `${baseUrl}/${apiVideo.file_path.replace(/\\/g, '/')}`
       : '',
-    duration: formatDuration(apiVideo.duration || 0),
-    uploadedAt: formatRelativeTime(apiVideo.created_at),
+    duration: formatVideoDuration(apiVideo.duration_video || apiVideo.duration),
+    uploadedAt: formatApiDate(apiVideo.created_at),
     isPrivate: false,
     tags: [],
     category: apiVideo.category,

--- a/src/modules/settings/ui/components/channels-tab/index.tsx
+++ b/src/modules/settings/ui/components/channels-tab/index.tsx
@@ -13,6 +13,7 @@ import { Upload, Trash2, Users, Calendar, Image as LucideImage } from "lucide-re
 import { useChannels } from '@/modules/settings/hooks/use-channels'
 import { ChannelCreate, ChannelUpdate } from '@/types/api'
 import { buildImageUrl } from '@/lib/api-config'
+import { formatApiDate } from '@/lib/utils/format'
 import Image from 'next/image'
 
 export const ChannelsTab = () => {
@@ -204,8 +205,7 @@ export const ChannelsTab = () => {
                 <div>
                   <p className="text-sm text-gray-500">Created</p>
                   <p className="font-medium">
-                    {/* TODO: Попросить бэкенд возвращать даты в ISO формате (2025-06-27T17:23:43.000Z) вместо "27.06.2025 17:23:43" */}
-                    {channel.created_at}
+                    {formatApiDate(channel.created_at)}
                   </p>
                 </div>
               </div>

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -28,17 +28,26 @@ export interface Channel {
 
 export interface Video {
   id: number
-  name: string
+  // Обновленные поля по новому API
+  channel_name: string // было name
   profile_image: string | null
-  title: string
-  description: string
+  video_title: string // было title
+  video_description: string // было description
   file_path: string
   thumbnail_path: string
   category: VideoCategory
-  views: number
-  created_at: string
+  video_views: number // было views
+  created_at: string // формат: "2025-07-03T15:30:00"
   like_amount: number
+  dislike_amount?: number // новое поле
   duration?: number
+  duration_video?: string // новое поле в формате "02:00"
+  
+  // Оставляем старые поля для совместимости
+  name?: string // @deprecated использовать channel_name
+  title?: string // @deprecated использовать video_title
+  description?: string // @deprecated использовать video_description
+  views?: number // @deprecated использовать video_views
 }
 
 export interface Like {


### PR DESCRIPTION
This pull request introduces updates to support a new API schema while maintaining backward compatibility. Key changes include the addition of new API fields, updates to utility functions for formatting, and modifications to components and tests to handle the new schema. Below is a summary of the most important changes grouped by theme:

### API Schema Updates
* Updated the `Video` interface in `src/types/api.ts` to include new fields such as `video_title`, `video_description`, `video_views`, `dislike_amount`, and `duration_video`. Deprecated older fields like `title`, `description`, and `views` for compatibility.

### Utility Enhancements
* Added `formatApiDate` and `formatVideoDuration` utility functions in `src/lib/utils/format.ts` to handle date formatting and video duration processing.
* Updated the `mapApiVideoToVideo` function in `src/lib/utils/video-mapper.ts` to use the new API fields with fallbacks to deprecated fields. [[1]](diffhunk://#diff-14604ed56d2aeb4073e196629ea32872a4ba58adba804d8ef43c8ef44d3b7332L16-R25) [[2]](diffhunk://#diff-14604ed56d2aeb4073e196629ea32872a4ba58adba804d8ef43c8ef44d3b7332L40-R42)

### Component Updates
* Modified the `VideoCard` component in `src/components/video/video-grid.tsx` to use the new API fields (`video_title`, `video_views`, etc.) with fallbacks to older fields. Updated the display of video duration and creation date using the new utility functions. [[1]](diffhunk://#diff-efe5bd6bdf380e4fae389704d946c2fe56068590a5b2d3b003d8287207d118e4L38-R44) [[2]](diffhunk://#diff-efe5bd6bdf380e4fae389704d946c2fe56068590a5b2d3b003d8287207d118e4L89-R105)
* Updated the `ChannelsTab` component in `src/modules/settings/ui/components/channels-tab/index.tsx` to format the `created_at` field using `formatApiDate`.

### Test Adjustments
* Replaced tests for `formatSubscriberCount` with new tests for `formatApiDate` and `formatVideoDuration` in `src/__tests__/utils/format.test.ts`.
* Updated mock data in `src/__tests__/api-client.test.ts` to reflect the new API fields.

### Dependency Updates
* Added `@types/date-fns` to `package.json` to support date formatting in the new utility functions.